### PR TITLE
Don't call GWs with no valid path and improve reporting of output directories  

### DIFF
--- a/src/TransitionSolver/cli.py
+++ b/src/TransitionSolver/cli.py
@@ -272,6 +272,18 @@ def cli(
             tr_report, tr_fig, phase_structure_raw, ctx, folder
         )
 
+    console.rule("[bold red]Results")
+    console.print(
+        Text.assemble("Transition results saved to: ", (folder, "bold magenta"))
+    )
+
+    if not any(path["valid"] and path["transitions"] for path in tr_report["paths"]):
+        console.print(
+            "No relevant transition detected in the phase history; "
+            "skipping gravitational wave analysis."
+        )
+        return
+
     detectors = [DETECTORS[d] for d in detector]
     ptas = [PTAS[p] for p in pta]
 
@@ -284,7 +296,23 @@ def cli(
     console.print(gw_report)
 
     with Status("Saving gravitational wave results"):
-        folder = save_gw_outputs(tr_report, gw_fig, analyser, detectors, folder)
+        folder, gw_path_dirs = save_gw_outputs(
+            tr_report, gw_fig, analyser, detectors, folder
+        )
 
-    console.rule("[bold red]Results")
-    console.print(Text.assemble("Results saved to: ", (folder, "bold magenta")))
+    console.print(
+        Text.assemble(
+            "Gravitational wave results also saved in: ",
+            (folder, "bold magenta"),
+        )
+    )
+    for path in gw_path_dirs:
+        phases = " → ".join(str(p) for p in path["phases"])
+        transitions = ", ".join(path["transitions"])
+        console.print(
+            Text.assemble(
+                f"  Valid cosmological history path {path['index']} "
+                f"(phase sequence {phases}; transition IDs {transitions}): ",
+                (path["directory"], "bold magenta"),
+            )
+        )

--- a/src/TransitionSolver/report.py
+++ b/src/TransitionSolver/report.py
@@ -50,6 +50,7 @@ def save_transition_outputs(tr_report, tr_fig, phase_structure_raw, ctx, folder=
 def save_gw_outputs(tr_report, gw_fig, analyser, detectors, folder):
     """Save outputs that require successful GW analysis."""
     folder = prepare_results_folder(folder)
+    path_dirs = []
 
     gw_fig.savefig(folder / "gw.pdf")
 
@@ -67,10 +68,18 @@ def save_gw_outputs(tr_report, gw_fig, analyser, detectors, folder):
         # folder name
         path_dir = folder / f"path_{idx}_p{phases}_t{transitions}"
         path_dir.mkdir(parents=True, exist_ok=True)
+        path_dirs.append(
+            {
+                "index": idx,
+                "phases": path["phases"],
+                "transitions": path["transitions"],
+                "directory": str(path_dir),
+            }
+        )
 
         path_gw_report = analyser.report_for_transition_ids(path["transitions"], *detectors)
 
         savejson(path_gw_report, path_dir / "gw.json")
         savejson(path, path_dir / "tr_path.json")
 
-    return str(folder)
+    return str(folder), path_dirs


### PR DESCRIPTION
Do not call the GWs part when there is no valid path. Instead report there is no path to analyse, rather than calling it and getting an error as if something is wrong.   In addition tell the user where we save the Transition results are saved even in GWs does throw an error, and specify meaning of the GW path directories more clearly.